### PR TITLE
Independent test set

### DIFF
--- a/orderly/clean/cleaner.py
+++ b/orderly/clean/cleaner.py
@@ -767,7 +767,6 @@ class Cleaner:
         return df
 
 
-
 def get_matching_indices(
     df: pd.DataFrame,
     train_indices: NDArray[np.int64],
@@ -821,7 +820,6 @@ def get_matching_indices(
         for h in to_move:
             test_indices_to_move += find(test_hashes, h)  # type: ignore [no-untyped-call]
         matching_indices = [test_indices[i] for i in test_indices_to_move]
-
 
     return np.array(matching_indices)
 
@@ -1279,7 +1277,6 @@ def main(
 
         matching_indices = get_matching_indices(
             df, train_indices, test_indices, reactant_columns, product_columns
-
         )
 
         # drop the matching rows from the test set

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1300,4 +1300,3 @@ def test_move_rows_from_test_to_train_set() -> None:
     )
 
     assert np.equal(matching_indices, np.array([3, 4])).all()
-


### PR DESCRIPTION
This fixes #114 with the an algorithm for moving duplicate reactions from test set to the train set:

1. Creates a "hash" of each reaction that is independent of reactant and product order
2. Finds any reaction hashes that are in both the train and test sets
3. Finds the indices of these matching hashes in the test set